### PR TITLE
Setup prod config for publishing

### DIFF
--- a/login-workflow/angular.json
+++ b/login-workflow/angular.json
@@ -18,6 +18,9 @@
             "demo": {
               "project": "ng-package-demo.json",
               "watch": true
+            },
+            "production": {
+              "tsConfig": "tsconfig.lib.json"
             }
           }
         },

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -16,7 +16,7 @@
     "start:example": "yarn install:dependencies && yarn link:workflow && cd example && yarn start"
   },
   "prettier": "@pxblue/prettier-config",
-  "private": true,
+  "private": false,
   "peerDependencies": {
     "@pxblue/angular-components": "^2.0.0"
   },

--- a/login-workflow/tsconfig.lib.json
+++ b/login-workflow/tsconfig.lib.json
@@ -22,7 +22,8 @@
     "strictMetadataEmit": true,
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
-    "enableResourceInlining": true
+    "enableResourceInlining": true,
+    "enableIvy": false
   },
   "exclude": [
     "test.ts",


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Setup production configuration so we can build without ivy for npm publishing.